### PR TITLE
Migration of high-level script wrappers from dashboard to the repository with the rest of management scripts

### DIFF
--- a/server/scripts/appchange_station.sh
+++ b/server/scripts/appchange_station.sh
@@ -22,10 +22,11 @@ echo "Changing top app of station $station_id to $app_id"
 
 cd $DOCKAPP_PATH
 ./topswitch_update.sh $station_id $app_id
+last_rc=$?
 
-if [ "$?" -ne "0" ]; then
-  echo >&2 "topswitch_update.sh returned $?. Changing top app of station $station_id cancelled."
-  exit $?;
+if [ "$last_rc" -ne "0" ]; then
+  echo >&2 "topswitch_update.sh returned $last_rc. Changing top app of station $station_id cancelled."
+  exit 1;
 fi
 
 echo "Finished changing top app of $station_id"

--- a/server/scripts/appchange_station.sh
+++ b/server/scripts/appchange_station.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+if [ -z "$DOCKAPP_PATH" ]; then
+>&2 echo "The DOCKAPP_PATH environment variable is not set. Set it to the directory where DockApp is installed".
+exit 1
+fi
+
+if [ -z "$1" ]; then
+  >&2 echo "First argument missing: station_id."
+  exit 1
+fi
+
+if [ -z "$2" ]; then
+  >&2 echo "Second argument missing: app_id."
+  exit 1
+fi
+
+station_id=$1
+app_id=$2
+
+echo "Changing top app of station $station_id to $app_id"
+
+cd $DOCKAPP_PATH
+./topswitch_update.sh $station_id $app_id
+
+if [ "$?" -ne "0" ]; then
+  echo >&2 "topswitch_update.sh returned $?. Changing top app of station $station_id cancelled."
+  exit $?;
+fi
+
+echo "Finished changing top app of $station_id"

--- a/server/scripts/appchange_station.sh
+++ b/server/scripts/appchange_station.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-if [ -z "$DOCKAPP_PATH" ]; then
->&2 echo "The DOCKAPP_PATH environment variable is not set. Set it to the directory where DockApp is installed".
+if [ -z "$HILBERT_CLI_PATH" ]; then
+>&2 echo "The HILBERT_CLI_PATH environment variable is not set. Set it to the directory where hilbert-cli is installed".
 exit 1
 fi
 
@@ -20,7 +20,7 @@ app_id=$2
 
 echo "Changing top app of station $station_id to $app_id"
 
-cd $DOCKAPP_PATH
+cd $HILBERT_CLI_PATH
 ./topswitch_update.sh $station_id $app_id
 last_rc=$?
 

--- a/server/scripts/list_stations.sh
+++ b/server/scripts/list_stations.sh
@@ -1,24 +1,23 @@
 #!/usr/bin/env bash
 
-if [ "$1" = "" ]; then
->&2 echo "Usage: $0 <path to dockapp>"
+if [ -z "$DOCKAPP_PATH" ]; then
+>&2 echo "The DOCKAPP_PATH environment variable is not set. Set it to the directory where DockApp is installed".
 exit 1
 fi
 
-if [ ! -d $1/STATIONS ]; then
+if [ ! -d $DOCKAPP_PATH/STATIONS ]; then
 >&2 echo "STATIONS directory not found in dockapp path"
 exit 1
 fi
 
-if [ ! -f $1/STATIONS/list ]; then
+if [ ! -f $DOCKAPP_PATH/STATIONS/list ]; then
 >&2 echo "STATIONS/list not found in dockapp path"
 exit 1
 fi
 
 print_station()
 {
-  root_path=$1
-  station_name=$2
+  station_name=$1
 
   unset station_id
   unset station_type
@@ -28,23 +27,23 @@ print_station()
   unset possible_apps
   unset DM
 
-  if [ ! -d $1/STATIONS/$station_name ]; then
+  if [ ! -d $DOCKAPP_PATH/STATIONS/$station_name ]; then
   >&2 echo "Station directory STATIONS/$station_name not found in dockapp path"
   exit 1
   fi
 
-  if [ ! -f $1/STATIONS/$station_name/station.cfg ]; then
+  if [ ! -f $DOCKAPP_PATH/STATIONS/$station_name/station.cfg ]; then
   >&2 echo "Station configuration STATIONS/$station_name/station.cfg not found in dockapp path"
   exit 1
   fi
 
-  if [ ! -f $1/STATIONS/$station_name/startup.cfg ]; then
+  if [ ! -f $DOCKAPP_PATH/STATIONS/$station_name/startup.cfg ]; then
   >&2 echo "Station configuration STATIONS/$station_name/startup.cfg not found in dockapp path"
   exit 1
   fi
 
-  source $1/STATIONS/$station_name/station.cfg
-  source $1/STATIONS/$station_name/startup.cfg
+  source $DOCKAPP_PATH/STATIONS/$station_name/station.cfg
+  source $DOCKAPP_PATH/STATIONS/$station_name/startup.cfg
 
   echo "{"
   echo "\"id\": \"$station_id\","
@@ -82,13 +81,13 @@ print_station()
 echo "["
 
 first=1
-for station_name in $(cat $1/STATIONS/list | grep -v -E '^ *(#.*)? *$') ; do
+for station_name in $(cat $DOCKAPP_PATH/STATIONS/list | grep -v -E '^ *(#.*)? *$') ; do
   if [ "$first" -eq "1" ]; then
     first=0
   else
     echo ","
   fi
-  print_station $1 $station_name
+  print_station $station_name
 done
 
 echo "]"

--- a/server/scripts/list_stations.sh
+++ b/server/scripts/list_stations.sh
@@ -82,7 +82,7 @@ print_station()
 echo "["
 
 first=1
-for station_name in $(cat $1/STATIONS/list) ; do
+for station_name in $(cat $1/STATIONS/list | grep -v -E '^ *(#.*)? *$') ; do
   if [ "$first" -eq "1" ]; then
     first=0
   else

--- a/server/scripts/list_stations.sh
+++ b/server/scripts/list_stations.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+if [ "$1" = "" ]; then
+echo "Usage: $0 <path to dockapp>"
+exit 1
+fi
+
+print_station()
+{
+  root_path=$1
+  station_name=$2
+
+  unset station_id
+  unset station_type
+  unset CFG_DIR
+  unset background_services
+  unset default_app
+  unset possible_apps
+  unset DM
+
+  source $1/STATIONS/$station_name/station.cfg
+  source $1/STATIONS/$station_name/startup.cfg
+
+  echo "{"
+  echo "\"id\": \"$station_id\","
+  echo "\"name\": \"$station_name\","
+  echo "\"type\": \"$station_type\","
+#  echo "\"cfg_dir\": \"$CFG_DIR\","
+#  echo "\"background_services\": \"$background_services\","
+  echo "\"default_app\": \"$default_app\","
+
+  echo "\"possible_apps\": ["
+  local first=1
+  for possible_app in $possible_apps; do
+    if [ "$first" -eq "1" ]; then
+      first=0
+    else
+      echo ","
+    fi
+    echo -n "\"$possible_app\""
+  done
+  echo ""
+  echo "]"
+
+#  echo "\"DM\": \"$DM\""
+  echo "}"
+
+  unset station_id
+  unset station_type
+  unset CFG_DIR
+  unset background_services
+  unset default_app
+  unset possible_apps
+  unset DM
+}
+
+echo "{"
+
+echo "\"stations\": ["
+
+first=1
+for station_name in $(cat $1/STATIONS/list) ; do
+  if [ "$first" -eq "1" ]; then
+    first=0
+  else
+    echo ","
+  fi
+  print_station $1 $station_name
+done
+
+echo "]"
+echo "}"

--- a/server/scripts/list_stations.sh
+++ b/server/scripts/list_stations.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 
-if [ -z "$DOCKAPP_PATH" ]; then
->&2 echo "The DOCKAPP_PATH environment variable is not set. Set it to the directory where DockApp is installed".
+if [ -z "$HILBERT_CLI_PATH" ]; then
+>&2 echo "The HILBERT_CLI_PATH environment variable is not set. Set it to the directory where hilbert-cli is installed".
 exit 1
 fi
 
-if [ ! -d $DOCKAPP_PATH/STATIONS ]; then
->&2 echo "STATIONS directory not found in dockapp path"
+if [ ! -d $HILBERT_CLI_PATH/STATIONS ]; then
+>&2 echo "STATIONS directory not found in the hilbert-cli path"
 exit 1
 fi
 
-if [ ! -f $DOCKAPP_PATH/STATIONS/list ]; then
->&2 echo "STATIONS/list not found in dockapp path"
+if [ ! -f $HILBERT_CLI_PATH/STATIONS/list ]; then
+>&2 echo "STATIONS/list not found in the hilbert-cli path"
 exit 1
 fi
 
@@ -27,23 +27,23 @@ print_station()
   unset possible_apps
   unset DM
 
-  if [ ! -d $DOCKAPP_PATH/STATIONS/$station_name ]; then
-  >&2 echo "Station directory STATIONS/$station_name not found in dockapp path"
+  if [ ! -d $HILBERT_CLI_PATH/STATIONS/$station_name ]; then
+  >&2 echo "Station directory STATIONS/$station_name not found in the hilbert-cli path"
   exit 1
   fi
 
-  if [ ! -f $DOCKAPP_PATH/STATIONS/$station_name/station.cfg ]; then
-  >&2 echo "Station configuration STATIONS/$station_name/station.cfg not found in dockapp path"
+  if [ ! -f $HILBERT_CLI_PATH/STATIONS/$station_name/station.cfg ]; then
+  >&2 echo "Station configuration STATIONS/$station_name/station.cfg not found in the hilbert-cli path"
   exit 1
   fi
 
-  if [ ! -f $DOCKAPP_PATH/STATIONS/$station_name/startup.cfg ]; then
-  >&2 echo "Station configuration STATIONS/$station_name/startup.cfg not found in dockapp path"
+  if [ ! -f $HILBERT_CLI_PATH/STATIONS/$station_name/startup.cfg ]; then
+  >&2 echo "Station configuration STATIONS/$station_name/startup.cfg not found in the hilbert-cli path"
   exit 1
   fi
 
-  source $DOCKAPP_PATH/STATIONS/$station_name/station.cfg
-  source $DOCKAPP_PATH/STATIONS/$station_name/startup.cfg
+  source $HILBERT_CLI_PATH/STATIONS/$station_name/station.cfg
+  source $HILBERT_CLI_PATH/STATIONS/$station_name/startup.cfg
 
   echo "{"
   echo "\"id\": \"$station_id\","
@@ -81,7 +81,7 @@ print_station()
 echo "["
 
 first=1
-for station_name in $(cat $DOCKAPP_PATH/STATIONS/list | grep -v -E '^ *(#.*)? *$') ; do
+for station_name in $(cat $HILBERT_CLI_PATH/STATIONS/list | grep -v -E '^ *(#.*)? *$') ; do
   if [ "$first" -eq "1" ]; then
     first=0
   else

--- a/server/scripts/list_stations.sh
+++ b/server/scripts/list_stations.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 
 if [ "$1" = "" ]; then
-echo "Usage: $0 <path to dockapp>"
+>&2 echo "Usage: $0 <path to dockapp>"
+exit 1
+fi
+
+if [ ! -d $1/STATIONS ]; then
+>&2 echo "STATIONS directory not found in dockapp path"
+exit 1
+fi
+
+if [ ! -f $1/STATIONS/list ]; then
+>&2 echo "STATIONS/list not found in dockapp path"
 exit 1
 fi
 
@@ -17,6 +27,21 @@ print_station()
   unset default_app
   unset possible_apps
   unset DM
+
+  if [ ! -d $1/STATIONS/$station_name ]; then
+  >&2 echo "Station directory STATIONS/$station_name not found in dockapp path"
+  exit 1
+  fi
+
+  if [ ! -f $1/STATIONS/$station_name/station.cfg ]; then
+  >&2 echo "Station configuration STATIONS/$station_name/station.cfg not found in dockapp path"
+  exit 1
+  fi
+
+  if [ ! -f $1/STATIONS/$station_name/startup.cfg ]; then
+  >&2 echo "Station configuration STATIONS/$station_name/startup.cfg not found in dockapp path"
+  exit 1
+  fi
 
   source $1/STATIONS/$station_name/station.cfg
   source $1/STATIONS/$station_name/startup.cfg
@@ -54,9 +79,7 @@ print_station()
   unset DM
 }
 
-echo "{"
-
-echo "\"stations\": ["
+echo "["
 
 first=1
 for station_name in $(cat $1/STATIONS/list) ; do
@@ -69,4 +92,3 @@ for station_name in $(cat $1/STATIONS/list) ; do
 done
 
 echo "]"
-echo "}"

--- a/server/scripts/start_station.sh
+++ b/server/scripts/start_station.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-if [ -z "$DOCKAPP_PATH" ]; then
-  >&2 echo "The DOCKAPP_PATH environment variable is not set. Set it to the directory where DockApp is installed".
+if [ -z "$HILBERT_CLI_PATH" ]; then
+  >&2 echo "The HILBERT_CLI_PATH environment variable is not set. Set it to the directory where hilbert-cli is installed".
   exit 1
 fi
 
@@ -15,7 +15,7 @@ station_id=$1
 echo "Starting station $station_id"
 
 echo "1. Call start.sh"
-cd $DOCKAPP_PATH
+cd $HILBERT_CLI_PATH
 ./start.sh $station_id
 last_rc=$?
 
@@ -25,7 +25,7 @@ if [ "$last_rc" -ne "0" ]; then
 fi
 
 echo "2. Call deploy.sh"
-cd $DOCKAPP_PATH
+cd $HILBERT_CLI_PATH
 ./deploy.sh $station_id
 last_rc=$?
 
@@ -35,7 +35,7 @@ if [ "$last_rc" -ne "0" ]; then
 fi
 
 echo "3. Call prepare.sh"
-cd $DOCKAPP_PATH
+cd $HILBERT_CLI_PATH
 ./prepare.sh $station_id
 last_rc=$?
 
@@ -45,7 +45,7 @@ if [ "$last_rc" -ne "0" ]; then
 fi
 
 echo "4. Call default_update.sh"
-cd $DOCKAPP_PATH
+cd $HILBERT_CLI_PATH
 ./default_update.sh $station_id
 last_rc=$?
 

--- a/server/scripts/start_station.sh
+++ b/server/scripts/start_station.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+if [ -z "$DOCKAPP_PATH" ]; then
+  >&2 echo "The DOCKAPP_PATH environment variable is not set. Set it to the directory where DockApp is installed".
+  exit 1
+fi
+
+if [ -z "$1" ]; then
+  >&2 echo "First argument missing: station_id."
+  exit 1
+fi
+
+station_id=$1
+
+echo "Starting station $station_id"
+
+echo "1. Call start.sh"
+cd $DOCKAPP_PATH
+./start.sh $station_id
+
+if [ "$?" -ne "0" ]; then
+  echo >&2 "start.sh returned $?. Starting station $station_id cancelled."
+  exit $?;
+fi
+
+echo "2. Call deploy.sh"
+cd $DOCKAPP_PATH
+./deploy.sh $station_id
+
+if [ "$?" -ne "0" ]; then
+  echo >&2 "deploy.sh returned $?.  Starting station $station_id cancelled."
+  exit $?;
+fi
+
+echo "3. Call prepare.sh"
+cd $DOCKAPP_PATH
+./prepare.sh $station_id
+
+if [ "$?" -ne "0" ]; then
+  echo >&2 "prepare.sh returned $?. Starting station $station_id cancelled."
+  exit $?;
+fi
+
+echo "4. Call default_update.sh"
+cd $DOCKAPP_PATH
+./default_update.sh $station_id
+
+if [ "$?" -ne "0" ]; then
+  echo >&2 "default_update.sh returned $?. Starting station $station_id cancelled."
+  exit $?;
+fi
+
+echo "Finished starting station $station_id"

--- a/server/scripts/start_station.sh
+++ b/server/scripts/start_station.sh
@@ -17,37 +17,41 @@ echo "Starting station $station_id"
 echo "1. Call start.sh"
 cd $DOCKAPP_PATH
 ./start.sh $station_id
+last_rc=$?
 
-if [ "$?" -ne "0" ]; then
-  echo >&2 "start.sh returned $?. Starting station $station_id cancelled."
-  exit $?;
+if [ "$last_rc" -ne "0" ]; then
+  echo >&2 "start.sh returned $last_rc. Starting station $station_id cancelled."
+  exit 1;
 fi
 
 echo "2. Call deploy.sh"
 cd $DOCKAPP_PATH
 ./deploy.sh $station_id
+last_rc=$?
 
-if [ "$?" -ne "0" ]; then
-  echo >&2 "deploy.sh returned $?.  Starting station $station_id cancelled."
-  exit $?;
+if [ "$last_rc" -ne "0" ]; then
+  echo >&2 "deploy.sh returned $last_rc.  Starting station $station_id cancelled."
+  exit 1;
 fi
 
 echo "3. Call prepare.sh"
 cd $DOCKAPP_PATH
 ./prepare.sh $station_id
+last_rc=$?
 
-if [ "$?" -ne "0" ]; then
-  echo >&2 "prepare.sh returned $?. Starting station $station_id cancelled."
-  exit $?;
+if [ "$last_rc" -ne "0" ]; then
+  echo >&2 "prepare.sh returned $last_rc. Starting station $station_id cancelled."
+  exit 1;
 fi
 
 echo "4. Call default_update.sh"
 cd $DOCKAPP_PATH
 ./default_update.sh $station_id
+last_rc=$?
 
-if [ "$?" -ne "0" ]; then
-  echo >&2 "default_update.sh returned $?. Starting station $station_id cancelled."
-  exit $?;
+if [ "$last_rc" -ne "0" ]; then
+  echo >&2 "default_update.sh returned $last_rc. Starting station $station_id cancelled."
+  exit 1;
 fi
 
 echo "Finished starting station $station_id"

--- a/server/scripts/stop_station.sh
+++ b/server/scripts/stop_station.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+if [ -z "$DOCKAPP_PATH" ]; then
+>&2 echo "The DOCKAPP_PATH environment variable is not set. Set it to the directory where DockApp is installed".
+exit 1
+fi
+
+if [ -z "$1" ]; then
+  >&2 echo "First argument missing: station_id."
+  exit 1
+fi
+
+station_id=$1
+
+echo "Stopping station $station_id"
+echo "1. Call finishall.sh"
+cd $DOCKAPP_PATH
+./finishall.sh $station_id
+
+if [ "$?" -ne "0" ]; then
+  echo >&2 "finishall.sh returned $?. Stopping station $station_id cancelled."
+  exit $?;
+fi
+
+echo "2. Call shutdown.sh"
+cd $DOCKAPP_PATH
+./shutdown.sh $station_id -h now
+
+if [ "$?" -ne "0" ]; then
+  echo >&2 "shutdown.sh returned $?. Stopping station $station_id cancelled."
+  exit $?;
+fi
+
+echo "Finished stopping station $station_id"

--- a/server/scripts/stop_station.sh
+++ b/server/scripts/stop_station.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-if [ -z "$DOCKAPP_PATH" ]; then
->&2 echo "The DOCKAPP_PATH environment variable is not set. Set it to the directory where DockApp is installed".
+if [ -z "$HILBERT_CLI_PATH" ]; then
+>&2 echo "The HILBERT_CLI_PATH environment variable is not set. Set it to the directory where hilbert-cli is installed".
 exit 1
 fi
 
@@ -14,7 +14,7 @@ station_id=$1
 
 echo "Stopping station $station_id"
 echo "1. Call finishall.sh"
-cd $DOCKAPP_PATH
+cd $HILBERT_CLI_PATH
 ./finishall.sh $station_id
 last_rc=$?
 
@@ -24,7 +24,7 @@ if [ "$last_rc" -ne "0" ]; then
 fi
 
 echo "2. Call shutdown.sh"
-cd $DOCKAPP_PATH
+cd $HILBERT_CLI_PATH
 ./shutdown.sh $station_id -h now
 last_rc=$?
 

--- a/server/scripts/stop_station.sh
+++ b/server/scripts/stop_station.sh
@@ -16,19 +16,21 @@ echo "Stopping station $station_id"
 echo "1. Call finishall.sh"
 cd $DOCKAPP_PATH
 ./finishall.sh $station_id
+last_rc=$?
 
-if [ "$?" -ne "0" ]; then
-  echo >&2 "finishall.sh returned $?. Stopping station $station_id cancelled."
-  exit $?;
+if [ "$last_rc" -ne "0" ]; then
+  echo >&2 "finishall.sh returned $last_rc. Stopping station $station_id cancelled."
+  exit 1;
 fi
 
 echo "2. Call shutdown.sh"
 cd $DOCKAPP_PATH
 ./shutdown.sh $station_id -h now
+last_rc=$?
 
-if [ "$?" -ne "0" ]; then
-  echo >&2 "shutdown.sh returned $?. Stopping station $station_id cancelled."
-  exit $?;
+if [ "$last_rc" -ne "0" ]; then
+  echo >&2 "shutdown.sh returned $last_rc. Stopping station $station_id cancelled."
+  exit 1;
 fi
 
 echo "Finished stopping station $station_id"


### PR DESCRIPTION
Note: the commit history from `hilbert/hilbert-ui` is preserved as a feature branch. 

| Original tags | Original Commits Messages |
| --- | --- |
| **v0.8** | Changes references to DockApp to hilbert-cli in code elements (classes, methods, variables, etc.). |
| **v0.7.1, v0.7, v0.6, v0.5.1** | Fix wrapping script management of script return codes. |
| **v0.5** | Interface with dockapp through own wrapping scripts. |
| **v0.4.2** | Change the list_stations.sh script to handle # comments in the list of stations. |
| **v0.4.1, v0.4, v0.3** | Add Station class to track station state. Change the way station cfg is read. |
| **v0.2.1, v0.2, v0.1** | Prototype with simulated dockapp. |

This PR closes #6  and closes hilbert/hilbert-docker-images#36.
