### PR TITLE
Add subcommand to open an interactive secure shell (ssh) on a station

### DIFF
--- a/hilbert_config/hilbert_cli_config.py
+++ b/hilbert_config/hilbert_cli_config.py
@@ -2444,6 +2444,29 @@ class Station(BaseRecordValidator):  # Wrapper?
 
         return poweron.start()  # , action_args????
 
+    def ssh(self):
+        _a = self.get_address()
+
+        assert _a is not None
+        assert isinstance(_a, HostAddress)
+
+        try:
+            _ret = _a.ssh([])
+        except:
+            s = "Could not SSH into station {}".format(_a)
+            if not PEDANTIC:
+                log.warning(s)
+                return False
+            else:
+                log.exception(s)
+                raise
+
+        if _ret != 0:
+            return False
+
+        return (_ret == 0)
+
+
     def run_action(self, action, action_args):
         """
         Run the given action on/with this station
@@ -2456,11 +2479,12 @@ class Station(BaseRecordValidator):  # Wrapper?
                 app_change <ApplicationID>
 #                start [<ServiceID/ApplicationID>]
 #                finish [<ServiceID/ApplicationID>]
+                ssh
 
         :return: nothing.
         """
 
-        if action not in ['start', 'stop', 'cfg_deploy', 'app_change']:
+        if action not in ['start', 'stop', 'cfg_deploy', 'app_change', 'ssh']:
             raise Exception("Running action '{0}({1})' is not supported!".format(action, action_args))
 
         # Run 'ssh address hilbert-station action action_args'?!
@@ -2472,6 +2496,8 @@ class Station(BaseRecordValidator):  # Wrapper?
             _ret = self.shutdown()  # action_args
         elif action == 'app_change':
             _ret = self.app_change(action_args)  # ApplicationID
+        elif action == 'ssh':
+            _ret = self.ssh()  # action_args
 
         # elif action == 'start':
         #            self.start_service(action_args)

--- a/tools/hilbert.py
+++ b/tools/hilbert.py
@@ -675,6 +675,23 @@ def cmd_app_change(parser, context, args):
 
     return args
 
+@subcmd('ssh', help="connect to a station via SSH")
+def cmd_ssh(parser, context, args):
+    action = 'ssh'
+    log.debug("Running 'cmd_{}'".format(action))
+
+    group = parser.add_mutually_exclusive_group()
+
+    group.add_argument('--configfile', required=False,
+                       help="specify input .YAML file (default: 'Hilbert.yml')")
+    group.add_argument('--configdump', required=False,
+                       help="specify input dump file")
+
+    parser.add_argument('StationID', help="specify the station")
+
+    cmd_action(parser, context, args, Action=action, appIdRequired=False)
+
+    return args
 
 # @subcmd('run_action', help='run specified action on given station with given arguments...')
 def cmd_run_action(parser, context, args):


### PR DESCRIPTION
This is a convinience subcommand to be able to log into a station via ssh using the station id provided in `Hilbert.yaml`.