### PR TITLE
Add subcommand cfg_query for extracting information out of the YAML config file

### DIFF
--- a/tools/hilbert.py
+++ b/tools/hilbert.py
@@ -675,6 +675,41 @@ def cmd_app_change(parser, context, args):
 
     return args
 
+@subcmd('cfg_query', help="query configuration properties")
+def cmd_cfg_query(parser, context, args):
+    action = 'cfg_query'
+    log.debug("Running 'cmd_{}'".format(action))
+
+    group = parser.add_mutually_exclusive_group()
+
+    group.add_argument('--configfile', required=False,
+                       help="specify input .YAML file (default: 'Hilbert.yml')")
+    group.add_argument('--configdump', required=False,
+                       help="specify input dump file")
+
+    parser.add_argument('QueryString', help="specify the query")
+
+    args = parser.parse_args(args)
+
+    log.debug("Querying '{}' from the configuration...".format(args.QueryString))
+
+    obj = None
+    try:
+        obj = cmd_list(parser, context, args, args.QueryString)
+    except:
+        log.exception("Sorry could not get the result of query '{}' from the input file!".format(args.QueryString))
+        sys.exit(1)
+
+    assert obj is not None
+
+    if isinstance(obj, BaseValidator):
+        yaml_dump(obj.data_dump(),sys.stdout)
+    elif isinstance(obj, (str, int, float, complex)):
+        print(obj)
+    else:
+        yaml.dump(obj,sys.stdout)
+
+    return args
 
 # @subcmd('run_action', help='run specified action on given station with given arguments...')
 def cmd_run_action(parser, context, args):


### PR DESCRIPTION
This subcommand allows to do basic queries on the YAML configuration like so:
```
$ python3 tools/hilbert.py cfg_query --configfile tests/data/Hilbert.yml Stations/testhost1/address/data
test1.host.dns.name
```
This allows to create external tools and aliases for certain commands, e.g. SSHing into a station could be done via
```
$ ssh -F $HILBERT_SERVER_CONFIG_SSH_PATH `python3 tools/hilbert.py cfg_query --configfile tests/data/Hilbert.yml Stations/testhost1/address/data` cmd
```
without needing to rely on external YAML parser and validator.

This is related to hilbert/hilbert-cli#63 and hilbert/hilbert-cli#59 .

The current implementation is unfinished:
- the subcommand name `cfg_query` is subject to discussion (I named it similar to `cfg_deploy`)
- the query `Stations/testhost1/address` (without `/data`) leads to
    ```
    test1.host.dns.name
    ...
    ```
    i.e. an additional second line with `...` is printed which causes problems if you want to use this in scripts (because it only seems to happen if the result would have been a one-liner). I introduced a special case that doesn't call `yaml_dump` for the internal data types `str, int, float, complex` (which are often returned by `/data` queries on leaf nodes), but I didn't change the default semantics for everything derived from `BaseValidator`. See further comments in the code of `cfg_query`. 