### PR TITLE
Improved initial `testapp` configuration

### DIFF
--- a/rpmbuild/SPECS/hilbert-testapp.spec
+++ b/rpmbuild/SPECS/hilbert-testapp.spec
@@ -17,7 +17,7 @@ Name:           hilbert-testapp
 Version:        0.9.0
 
 License:        Apache License, Version 2.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 
 URL:            https://github.com/hilbert/%{origname}
 Source:         %{origname}.tar.gz

--- a/station/station_configs/testapp/docker-compose.x11vnc.yml
+++ b/station/station_configs/testapp/docker-compose.x11vnc.yml
@@ -18,4 +18,6 @@ services:
      - --skip-startup-files
      - --
     command:
-     - /usr/local/bin/x11vnc.sh
+     - /bin/bash
+     - -c 
+     - 'setup_ogl.sh; x11vnc.sh'

--- a/station/station_configs/testapp/docker-compose.yml
+++ b/station/station_configs/testapp/docker-compose.yml
@@ -78,9 +78,9 @@ services:
      - "is_top_app=0"
     environment:
      - QT_X11_NO_MITSHM=1
-     - XLIB_SKIP_ARGB_VISUALS=1
      - "XAUTHORITY=${HILBERT_XAUTH:-/tmp/.docker.xauth}"
      - DISPLAY
+#     - XLIB_SKIP_ARGB_VISUALS=1 # removed to avoid issues with transparency
 #=${DISPLAY:-:0}"
     stdin_open: false
     tty: false


### PR DESCRIPTION
* avoid problems with transparency (by not setting `XLIB_SKIP_ARGB_VISUALS`)
* make use of custom OpenGL by Hilbert's x11vnc service